### PR TITLE
Issue #252215 feat: Implementation of pre validation of document using keywords

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { NetworkCache } from './entity/network-cache.entity';
 import { StorageProviderModule } from './services/storage-providers/storage-provider.module';
 import { OcrModule } from './services/ocr/ocr.module';
 import { OcrMappingModule } from './services/ocr-mapping/ocr-mapping.module';
+import { DocumentValidationModule } from './services/document-validation/document-validation.module';
 import { I18nModule } from './common/i18n.module';
 
 @Module({
@@ -66,6 +67,7 @@ import { I18nModule } from './common/i18n.module';
 		StorageProviderModule,
 		OcrModule,
 		OcrMappingModule,
+		DocumentValidationModule,
 		I18nModule,
 	],
 	controllers: [AppController],

--- a/src/config/prompts.config.ts
+++ b/src/config/prompts.config.ts
@@ -1,11 +1,11 @@
 /**
  * IMPROVED Prompts Configuration
- * Centralized AI prompts with generic document validation (no hardcoded document types)
+ * Centralized AI prompts for document data extraction
  */
 const DEFAULT_PROMPTS = {
   ocrExtraction: `Extract all text from this document. Return only the extracted text, preserving layout as much as possible. No explanations or formatting.`,
 
-  ocrMapping: `YOU ARE A DOCUMENT SECURITY VALIDATOR. YOUR PRIMARY DUTY IS TO REJECT MISMATCHED DOCUMENTS. OUTPUT: PURE JSON ONLY. NO TEXT. NO MARKDOWN. NO EXPLANATIONS.
+  ocrMapping: `YOU ARE A DOCUMENT DATA EXTRACTOR. YOUR JOB IS TO EXTRACT STRUCTURED DATA FROM DOCUMENTS. OUTPUT: PURE JSON ONLY. NO TEXT. NO MARKDOWN. NO EXPLANATIONS.
 
 DOCUMENT_TEXT:
 {extractedText}
@@ -13,7 +13,97 @@ DOCUMENT_TEXT:
 SCHEMA:
 {schema}
 
-PHASE 1: DOCUMENT TYPE VALIDATION (MANDATORY - EXECUTE FIRST): CRITICAL: Your PRIMARY job is to CATCH WRONG DOCUMENTS. Be EXTREMELY suspicious. VALIDATION APPROACH - SMART DOCUMENT MATCHING: SPECIAL EXCEPTION FOR OTR DOCUMENTS ONLY: IF {expectedDocumentName} contains OTR or One Time Registration (case-insensitive), APPLY RELAXED VALIDATION: 1. Check if document contains OTR identifier pattern: Look for OTR followed by colon, hyphen, or space and then a number (e.g., OTR:- 250100369389914, OTR: 250100369389914, OTR 250100369389914). This can appear ANYWHERE in the document (header, body, profile section). 2. Check for at least 3 profile/identity fields from schema: Look for fields like name, applicant_name, father_name, mother_name, date_of_birth, mobile, gender, address in the document. 3. IF BOTH CONDITIONS MET (OTR identifier found AND 3+ schema fields present): SET isValidDocument equals true IMMEDIATELY. SKIP all other validation steps. PROCEED directly to Phase 2 extraction. This includes profile pages, registration pages, or any document showing OTR number with user details. 4. Document title or heading is NOT required for OTR documents. Words like My Profile, Profile Details, Registration Details are ACCEPTABLE for OTR only. FOR ALL OTHER DOCUMENTS (NON-OTR): APPLY EXTREMELY STRICT VALIDATION. NO EXCEPTIONS. NO RELAXATION. MANDATORY STEP 1: ANALYZE DOCUMENT TITLE AND HEADER (CRITICAL - FIRST 5-10 LINES): Read ONLY the FIRST 5-10 LINES of DOCUMENT_TEXT carefully. This is the MOST IMPORTANT STEP for non-OTR documents. Look for: A. MAIN DOCUMENT TITLE: Usually in CAPITAL LETTERS, BOLD, or prominent font at the top. This is typically the PRIMARY indicator of document type. Common positions: Line 1 to 5 of the document. Examples of what to look for: Certificate title, Document name, Form title, Official heading. B. ISSUING AUTHORITY: Organization name or government department name near the title. Often appears above or below the main title. C. DOCUMENT PURPOSE KEYWORDS: Words that indicate document type in the header section. Extract the EXACT document title text as it appears in these first lines. This title is your PRIMARY validation criterion. MANDATORY STEP 2: STRICT TITLE MATCHING (NO TOLERANCE FOR MISMATCH): Compare the extracted title from STEP 1 with EXPECTED_DOCUMENT_TYPE: {expectedDocumentName}. STRICT MATCHING RULES FOR NON-OTR DOCUMENTS: 1. DIRECT MATCH (REQUIRED): Document title MUST match {expectedDocumentName} either exactly or with close variants. Case-insensitive comparison allowed. Plural/singular variations allowed. 2. WORD-ORDER VARIATIONS (LIMITED ACCEPTANCE): Only accept if meaning is identical. Example: Income Certificate equals Certificate of Income. Be cautious: different word order can mean different documents. 3. SYNONYM MATCHES (VERY LIMITED): Only accept well-established synonyms for the same document type. Example: Mark Sheet equals Marksheet equals Grade Sheet. Be strict: many similar-sounding documents are actually different types. 4. REJECT IMMEDIATELY IF: Title explicitly states a DIFFERENT document type. Title mentions a different category of document. Title is missing or unclear in first 5-10 lines. Title has contradictory information. MANDATORY STEP 3: UNIQUE FIELD AND KEYWORD VALIDATION (CRITICAL): A. IDENTIFY DOCUMENT-SPECIFIC UNIQUE FIELDS (MOST IMPORTANT): Look at SCHEMA field names and identify UNIQUE fields that are specific to THIS document type ONLY. IGNORE COMMON FIELDS that appear in all documents: DO NOT count: name, applicant_name, person_name, student_name, candidate_name (these are in ALL documents). DO NOT count: father_name, mother_name, parent_name, guardian_name (common family fields). DO NOT count: date_of_birth, dob, birth_date (common in many documents). DO NOT count: address, district, state, city, pincode (common location fields). DO NOT count: mobile, phone, email, contact (common contact fields). DO NOT count: gender, age (common demographic fields). COUNT ONLY UNIQUE FIELDS specific to document type: Academic documents: roll_number, enrollment_number, marks, total_marks, percentage, grade, subject, class, standard, semester, exam_date, passing_year, institution_name, university_name. Government documents: certificate_number, certificate_date, issuing_authority, caste, category, income, annual_income, validity_period, domicile, residence_proof. Registration documents: registration_number, registration_date, application_number, otr_number, registration_status. Financial documents: amount, total_amount, fee_amount, receipt_number, transaction_id, payment_date, invoice_number. Property documents: property_id, ration_card_number, electricity_account_number, consumer_number. B. Scan DOCUMENT_TEXT for UNIQUE field values and keywords. Look for the actual field labels or related terms in the document. C. STRICT UNIQUE FIELD THRESHOLD FOR NON-OTR: Found 0-1 UNIQUE schema fields in document: REJECT immediately (common fields do not count). Found 2 UNIQUE schema fields: HIGH SUSPICION - only accept if title match is PERFECT AND both unique fields clearly present. Found 3+ UNIQUE schema fields: PROCEED to category check. CRITICAL: If schema has UNIQUE fields but document does NOT contain those field labels or values then REJECT immediately. Example: Schema expects marks and roll_number but document only has name and father_name then REJECT. D. CATEGORY COHERENCE (MANDATORY): Document MUST belong to same category as expected type. Categories: ACADEMIC (certificates, mark sheets, transcripts), GOVERNMENT/CIVIL (birth, caste, domicile, income certificates), FINANCIAL (receipts, salary, income proof), PROPERTY (address proof, utility bills). IF categories do NOT match: REJECT immediately. DECISION LOGIC FOR NON-OTR DOCUMENTS (EXTREMELY STRICT): SET isValidDocument equals true ONLY IF ALL CONDITIONS MET: 1. Document title in first 5-10 lines has STRONG MATCH with {expectedDocumentName}. 2. Found at least 2 UNIQUE document-specific fields (NOT common fields like name, father_name, dob) in document text. 3. Document category EXACTLY matches expected category. 4. NO contradictory evidence whatsoever. 5. You are HIGHLY CONFIDENT (97 percent or more) this is the correct document type. 6. The document has UNIQUE characteristics that distinguish it from other document types. SET isValidDocument equals false IF ANY OF THESE: 1. Document title in first 5-10 lines is DIFFERENT from {expectedDocumentName}. 2. Title is missing, unclear, or ambiguous in header section. 3. Found less than 2 UNIQUE schema-related fields (common fields like name do not count). 4. Document contains ONLY common fields (name, father_name, dob, address) but NO unique fields. 5. Document category does not match expected category. 6. Schema expects unique fields but document does not contain them. 7. Confidence level is below 97 percent. 8. ANY doubt, uncertainty, or suspicion about document match. 9. Document could potentially be a different type. 10. Document appears generic without distinguishing characteristics. CRITICAL CONFIDENCE RULE: If you cannot find clear UNIQUE identifiers or characteristics that distinguish this document from other types then SET isValidDocument equals false. Presence of common fields (name, father_name, mother_name, dob, address, mobile) alone is NOT sufficient evidence. You MUST find document-specific unique fields to validate. WHEN IN DOUBT: ALWAYS SET isValidDocument equals false for non-OTR documents. BETTER TO REJECT a correct document than ACCEPT a wrong one. LOW CONFIDENCE equals REJECT. IF isValidDocument equals false: STOP IMMEDIATELY. Return ONLY: open_brace isValidDocument: false close_brace. DO NOT extract any fields. DO NOT proceed to Phase 2. PHASE 2: DATA EXTRACTION (ONLY IF isValidDocument equals true): EXTRACTION PRINCIPLES: PRINCIPLE 1: YOU ARE A PHOTOCOPIER, NOT AN EDITOR - Extract text EXACTLY as it appears character-by-character. DO NOT clean, fix, correct, or improve any data. DO NOT remove invalid characters. DO NOT calculate missing values. DO NOT reformat dates or standardize formats. PRINCIPLE 2: EXTRACT ONLY FROM DOCUMENT_TEXT - Use ONLY text that exists verbatim in DOCUMENT_TEXT above. If text is not in DOCUMENT_TEXT then set to null. NEVER invent, guess, calculate, or infer values. PRINCIPLE 3: EXTRACT ONLY SCHEMA FIELDS - Extract ONLY fields listed in SCHEMA. NEVER add extra fields. Include ALL schema fields in output (use null if not found). PRINCIPLE 4: SMART FIELD MAPPING. Match schema field names to document labels intelligently: NAME FIELDS (student_name, applicant_name, person_name, candidate_name, name): Look for: Name:, Student Name:, Applicant:, Person is Name:, Full Name:. Also: Name after Mr., Miss, Mrs., Dr., Shri. Exclude: S/O, D/O, W/O, Father:, Mother:, Father's Name:, Mother's Name:. Extract EXACTLY as printed including numbers and special characters. IDENTIFIER FIELDS (roll_number, registration_no, certificate_no, otr_number): Look for: Roll No:, Reg No:, Certificate No:, ID:, OTR No:, OTR:, OTR:-, Registration Number:, Enrollment No:. Extract AS-IS preserving all formatting: ABC-123 maps to ABC-123, R2024 maps to R2024. Strip ONLY leading hyphens/colons from the immediate value: OTR:- 250100369389914 maps to 250100369389914. Keep embedded hyphens: ABC-123-XYZ stays ABC-123-XYZ. DATE FIELDS (date_of_birth, issue_date, exam_date): Extract EXACTLY as shown preserving all formatting. DO NOT reformat or standardize date formats. DO NOT fix invalid dates - extract as-is. AMOUNT FIELDS (total_fees_amount, income, salary, total_marks): Extract EXACTLY as printed preserving commas, decimals, currency symbols. If contains letters extract including letters (do not skip). If blank or empty then set to null. NEVER calculate from tables: If Total is blank, DO NOT sum items then null. ADDRESS FIELDS (address, district, state): Extract as shown in document. Keep formatting as-is. PARENT/FAMILY FIELDS (father_name, mother_name, guardian_name): Look for: Father's Name:, Father is Name:, Mother's Name:, Mother is Name:, Guardian:. Extract EXACTLY as printed. Do NOT confuse with applicant name. PRINCIPLE 5: HANDLE MISSING VALUES - Field not found then null. Field blank or empty or blank then null. Field unclear or ambiguous then null. PRINCIPLE 6: REJECT MEANINGLESS VALUES - Only punctuation (dash, period, slash) then null. Only whitespace then null. Otherwise extract what is there. OUTPUT FORMAT (MANDATORY): Return PURE JSON in ONE of these formats: FORMAT 1 dash Document validation FAILED: open_brace isValidDocument: false close_brace. FORMAT 2 dash Document validation PASSED: open_brace isValidDocument: true, field1: value or null, field2: value or null, open_paren ALL schema fields close_paren close_brace. JSON RULES: Start with open_brace, end with close_brace. Double quotes for keys and strings. Use null for missing (not empty string open_quote close_quote). Include ALL schema fields. NO markdown, NO explanations, NO text before or after JSON. EXAMPLES: EXAMPLE 1 dash Wrong Document: OUTPUT: open_brace isValidDocument: false close_brace. EXAMPLE 2 dash Valid Document: OUTPUT: open_brace isValidDocument: true, field1: extracted value, field2: null close_brace. NOW PROCESS THE INPUTS. RETURN ONLY JSON.`,
+DATA EXTRACTION INSTRUCTIONS:
+
+EXTRACTION PRINCIPLES:
+
+PRINCIPLE 1: YOU ARE A PHOTOCOPIER, NOT AN EDITOR
+- Extract text EXACTLY as it appears character-by-character.
+- DO NOT clean, fix, correct, or improve any data.
+- DO NOT remove invalid characters.
+- DO NOT calculate missing values.
+- DO NOT reformat dates or standardize formats.
+
+PRINCIPLE 2: EXTRACT ONLY FROM DOCUMENT_TEXT
+- Use ONLY text that exists verbatim in DOCUMENT_TEXT above.
+- If text is not in DOCUMENT_TEXT then set to null.
+- NEVER invent, guess, calculate, or infer values.
+
+PRINCIPLE 3: EXTRACT ONLY SCHEMA FIELDS
+- Extract ONLY fields listed in SCHEMA.
+- NEVER add extra fields.
+- Include ALL schema fields in output (use null if not found).
+
+PRINCIPLE 4: SMART FIELD MAPPING
+Match schema field names to document labels intelligently:
+
+NAME FIELDS (student_name, applicant_name, person_name, candidate_name, name):
+- Look for: Name:, Student Name:, Applicant:, Person Name:, Full Name:
+- Also: Name after Mr., Miss, Mrs., Dr., Shri
+- Exclude: S/O, D/O, W/O, Father:, Mother:, Father's Name:, Mother's Name:
+- Extract EXACTLY as printed including numbers and special characters
+
+IDENTIFIER FIELDS (roll_number, registration_no, certificate_no, otr_number):
+- Look for: Roll No:, Reg No:, Certificate No:, ID:, OTR No:, OTR:, OTR:-, Registration Number:, Enrollment No:
+- Extract AS-IS preserving all formatting: ABC-123 maps to ABC-123, R2024 maps to R2024
+- Strip ONLY leading hyphens/colons from the immediate value: OTR:- 250100369389914 maps to 250100369389914
+- Keep embedded hyphens: ABC-123-XYZ stays ABC-123-XYZ
+
+DATE FIELDS (date_of_birth, issue_date, exam_date):
+- Extract EXACTLY as shown preserving all formatting
+- DO NOT reformat or standardize date formats
+- DO NOT fix invalid dates - extract as-is
+
+AMOUNT FIELDS (total_fees_amount, income, salary, total_marks):
+- Extract EXACTLY as printed preserving commas, decimals, currency symbols
+- If contains letters extract including letters (do not skip)
+- If blank or empty then set to null
+- NEVER calculate from tables: If Total is blank, DO NOT sum items then null
+
+ADDRESS FIELDS (address, district, state):
+- Extract as shown in document
+- Keep formatting as-is
+
+PARENT/FAMILY FIELDS (father_name, mother_name, guardian_name):
+- Look for: Father's Name:, Father Name:, Mother's Name:, Mother Name:, Guardian:
+- Extract EXACTLY as printed
+- Do NOT confuse with applicant name
+
+PRINCIPLE 5: HANDLE MISSING VALUES
+- Field not found then null
+- Field blank or empty then null
+- Field unclear or ambiguous then null
+
+PRINCIPLE 6: REJECT MEANINGLESS VALUES
+- Only punctuation (dash, period, slash) then null
+- Only whitespace then null
+- Otherwise extract what is there
+
+OUTPUT FORMAT (MANDATORY):
+Return PURE JSON with all schema fields:
+{
+  "field1": "value or null",
+  "field2": "value or null",
+  ... (ALL schema fields)
+}
+
+JSON RULES:
+- Start with {, end with }
+- Double quotes for keys and strings
+- Use null for missing (not empty string "")
+- Include ALL schema fields
+- NO markdown, NO explanations, NO text before or after JSON
+
+EXAMPLE:
+{
+  "name": "John Doe",
+  "father_name": "Richard Doe",
+  "certificate_number": "ABC-12345",
+  "issue_date": "15/01/2024",
+  "marks": null
+}
+
+NOW PROCESS THE INPUTS. RETURN ONLY JSON.`,
 
   validation: 'Test'
 } as const;
@@ -40,14 +130,8 @@ export function getOcrMappingPromptTemplate(): string {
 export function buildOcrMappingPrompt(
   extractedText: string, 
   schema: Record<string, any>, 
-  expectedDocumentName: string,
   customPromptTemplate?: string | null
 ): string {
-  // Validate expectedDocumentName is provided
-  if (!expectedDocumentName || expectedDocumentName.trim() === '') {
-    throw new Error('EXPECTED_DOCUMENT_NAME_REQUIRED');
-  }
-  
   // Use custom prompt template if provided and not empty, otherwise fall back to default
   const promptTemplate = (customPromptTemplate && customPromptTemplate.trim() !== '') 
     ? customPromptTemplate 
@@ -58,8 +142,7 @@ export function buildOcrMappingPrompt(
   // The placeholders are wrapped in curly braces to avoid replacing plain text
   let prompt = promptTemplate
     .replaceAll('{extractedText}', extractedText)
-    .replaceAll('{schema}', JSON.stringify(schema, null, 2))
-    .replaceAll('{expectedDocumentName}', expectedDocumentName.trim());
+    .replaceAll('{schema}', JSON.stringify(schema, null, 2));
   
   return prompt;
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -12,6 +12,7 @@ import { UpdatePasswordDTO } from './dto/update-password.dto';
 import { UploadDocumentDto } from '@modules/users/dto/upload-document.dto';
 import { DocumentUploadService } from '@modules/document-upload/document-upload.service';
 import { I18nService } from 'src/common/services/i18n.service';
+import { DocumentValidationService } from '@services/document-validation/document-validation.service';
 
 const crypto = require('crypto');
 const axios = require('axios');
@@ -33,6 +34,7 @@ export class AuthService {
     private readonly walletService: WalletService,
     private readonly documentUploadService: DocumentUploadService,
     private readonly i18n: I18nService,
+    private readonly documentValidationService: DocumentValidationService,
   ) { }
 
   public async login(body: LoginDTO) {
@@ -516,21 +518,33 @@ export class AuthService {
       );
       this.loggerService.log(`⏱️ OCR Extraction took: ${Date.now() - ocrStartTime}ms`, 'AuthService');
 
-      // Step 5: Fetch vcFields
+      // Step 5: Keyword-based document validation (preValidation)
+      this.loggerService.log(`Starting keyword-based document validation: docName=${uploadDocumentDto.docName}, docType=${uploadDocumentDto.docType}, docSubType=${uploadDocumentDto.docSubType}`);
+      const keywordValidationResult = await this.documentValidationService.validateDocument(
+        ocrResult.extractedText,
+        uploadDocumentDto.docType,
+        uploadDocumentDto.docSubType,
+      );
+
+      if (!keywordValidationResult.isValid) {
+        const documentName = uploadDocumentDto.docName || 'Unknown';
+        this.loggerService.warn(`Keyword validation FAILED: ${keywordValidationResult.reason}`);
+        const translatedError = this.i18n.translateError('AUTH_DOCUMENT_TYPE_MISMATCH', locale, { documentName });
+        throw new BadRequestException(translatedError);
+      }
+
+      this.loggerService.log(`Keyword validation PASSED. Matched keywords: ${keywordValidationResult.matchedKeywords?.join(', ') || 'N/A'}`);
+
+      // Step 6: Fetch vcFields
       const vcFields = await this.userService.getVcFieldsForDocument(
         uploadDocumentDto.docType,
         uploadDocumentDto.docSubType,
       );
 
-      // Step 6: OCR → structured mapping
+      // Step 7: OCR → structured mapping
       let vcMapping = null;
       const mappingStartTime = Date.now();
       if (vcFields) {
-        // Pass docName from uploadDocumentDto for document type validation
-        const expectedDocumentName = uploadDocumentDto.docName;
-        if (!expectedDocumentName || expectedDocumentName.trim() === '') {
-          throw new BadRequestException('DOCUMENT_NAME_REQUIRED_FOR_VALIDATION');
-        }
         vcMapping = await this.userService.ocrMapping.mapAfterOcr(
           {
             text: ocrResult.extractedText,
@@ -538,10 +552,8 @@ export class AuthService {
             docSubType: uploadDocumentDto.docSubType,
           },
           vcFields,
-          expectedDocumentName,
+          locale,
         );
-
-
       } else {
         vcMapping = {
           mapped_data: {},
@@ -561,29 +573,12 @@ export class AuthService {
       );
       this.loggerService.log(`⏱️ OCR Mapping took: ${Date.now() - mappingStartTime}ms`, 'AuthService');
 
-      // Step 6.5: Check for validation errors BEFORE proceeding
+      // Check for validation errors BEFORE proceeding
       if (vcMapping?.validationErrors && vcMapping.validationErrors.length > 0) {
         this.loggerService.error(`Document validation failed with ${vcMapping.validationErrors.length} error(s)`);
         const errorMessages = vcMapping.validationErrors.map(err => err.error).join('; ');
         const translatedError = this.i18n.translateError('AUTH_DOCUMENT_VALIDATION_FAILED', locale, { errorMessages });
         throw new BadRequestException(translatedError);
-      }
-
-      // Step 7: Validate document type - check isValidDocument from LLM mapping result
-      if (vcMapping && 'isValidDocument' in vcMapping && vcMapping.isValidDocument !== undefined) {
-        const isValidDocument = vcMapping.isValidDocument;
-        this.loggerService.log(`Document type validation result from LLM: isValidDocument=${isValidDocument}, expectedDocumentName=${uploadDocumentDto.docName}`);
-
-        if (!isValidDocument) {
-          const documentName = uploadDocumentDto.docName || 'Unknown';
-          this.loggerService.warn(`Document type validation FAILED: LLM determined document does not match expected type "${documentName}". Stopping processing.`);
-          const translatedError = this.i18n.translateError('AUTH_DOCUMENT_TYPE_MISMATCH', locale, { documentName });
-          throw new BadRequestException(translatedError);
-        }
-        this.loggerService.log(`Document type validation PASSED: LLM confirmed document matches expected type "${uploadDocumentDto.docName}".`);
-      } else if (vcFields) {
-        // If vcFields exist but isValidDocument is missing, log warning but proceed (shouldn't happen with required expectedDocumentName)
-        this.loggerService.warn(`Document type validation: isValidDocument field missing from LLM response. Expected document type: ${uploadDocumentDto.docName}`);
       }
 
       this.loggerService.log('OTR Certificate processed successfully (OCR + mapping done)');

--- a/src/modules/document-upload/document-upload.service.ts
+++ b/src/modules/document-upload/document-upload.service.ts
@@ -185,7 +185,7 @@ export class DocumentUploadService {
         if (publicUrl) {
           this.logger.log(
             `Generated public URL: ${publicUrl}. ` +
-            `⚠️ Note: This URL will only work if bucket policies allow public read access (s3:GetObject). ` +
+            `Note: This URL will only work if bucket policies allow public read access (s3:GetObject). ` +
             `If ACLs are disabled and files are uploaded as private, ensure bucket policies are configured for public access.`,
           );
         }

--- a/src/modules/document-upload/document-upload.service.ts
+++ b/src/modules/document-upload/document-upload.service.ts
@@ -181,15 +181,6 @@ export class DocumentUploadService {
           }
         }
         
-        // Log warning about bucket policy requirement
-        if (publicUrl) {
-          this.logger.log(
-            `Generated public URL: ${publicUrl}. ` +
-            `Note: This URL will only work if bucket policies allow public read access (s3:GetObject). ` +
-            `If ACLs are disabled and files are uploaded as private, ensure bucket policies are configured for public access.`,
-          );
-        }
-        
         return publicUrl;
       } catch (error) {
         this.logger.error(

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -44,6 +44,7 @@ import { I18nService } from 'src/common/services/i18n.service';
 import { VcProcessingService } from './services/vc-processing.service';
 import { QRContentProcessorService } from '@services/ocr/services/qr-content-processor.service';
 import { UploadDocumentQrDto } from './dto/upload-document-qr.dto';
+import { DocumentValidationService } from '@services/document-validation/document-validation.service';
 
 type StatusUpdateInfo = {
 	attempted: boolean;
@@ -122,6 +123,7 @@ export class UserService {
 		private readonly i18n: I18nService,
 		private readonly vcProcessingService: VcProcessingService,
 		private readonly qrContentProcessor: QRContentProcessorService,
+		private readonly documentValidationService: DocumentValidationService,
 	) { }
 
 	/*  async create(createUserDto: CreateUserDto) {
@@ -2907,41 +2909,43 @@ export class UserService {
 				requiresQRProcessing,
 				documentConfig,
 				locale,
-			);
-			Logger.log(`⏱️ OCR Extraction took: ${Date.now() - ocrStartTime}ms`, 'UserService');
+		);
+		Logger.log(`⏱️ OCR Extraction took: ${Date.now() - ocrStartTime}ms`, 'UserService');
 
-			// Validate document type from OCR text and VC fields
-			Logger.log(`Starting document validation: docName=${uploadDocumentDto.docName}, docType=${uploadDocumentDto.docType}, docSubType=${uploadDocumentDto.docSubType}`);
-			const isValidDocument = await this.validateDocumentAndFields(
-				documentConfig,
-				ocrResult,
-				uploadDocumentDto,
-				issueVC,
-				locale,
-			);
+		// Step 1: Keyword-based document validation (preValidation)
+		Logger.log(`Starting keyword-based document validation: docName=${uploadDocumentDto.docName}, docType=${uploadDocumentDto.docType}, docSubType=${uploadDocumentDto.docSubType}`);
+		const keywordValidationResult = await this.documentValidationService.validateDocument(
+			ocrResult.extractedText,
+			uploadDocumentDto.docType,
+			uploadDocumentDto.docSubType,
+		);
 
-			if (isValidDocument === false) {
-				const documentName = uploadDocumentDto.docName || 'Unknown';
-				Logger.warn(`Document validation failed - returning error. Expected document type: ${documentName}`);
-				const errorMessage = this.i18n.translateError('DOCUMENT_TYPE_MISMATCH', locale, { documentName });
-				return new ErrorResponse({
-					statusCode: HttpStatus.BAD_REQUEST,
-					errorMessage,
-				});
-			}
+		if (!keywordValidationResult.isValid) {
+			const documentName = uploadDocumentDto.docName || 'Unknown';
+			Logger.warn(`Keyword validation FAILED: ${keywordValidationResult.reason}`);
+			const errorMessage = this.i18n.translateError('DOCUMENT_TYPE_MISMATCH', locale, { 
+				documentName,
+				reason: keywordValidationResult.reason 
+			});
+			return new ErrorResponse({
+				statusCode: HttpStatus.BAD_REQUEST,
+				errorMessage,
+			});
+		}
 
-			Logger.log(`Document validation passed or skipped. isValidDocument=${isValidDocument}, proceeding with document processing.`);
+		Logger.log(`Keyword validation PASSED. Matched keywords: ${keywordValidationResult.matchedKeywords?.join(', ') || 'N/A'}`);
 
-			// Check if this is a Dhiway VC_URL case - skip OCR mapping and use VC data directly
-			const isDhiwayVcUrl = this.isDhiwayVcUrlDocument(ocrResult, uploadDocumentDto, documentConfig);
+	// Step 2: Validate document type from OCR text and VC fields (includes OCR mapping)
+	Logger.log(`Starting field validation: docName=${uploadDocumentDto.docName}, docType=${uploadDocumentDto.docType}, docSubType=${uploadDocumentDto.docSubType}`);
+	const { vcMapping } = await this.validateDocumentAndFields(
+		documentConfig,
+		ocrResult,
+		uploadDocumentDto,
+		issueVC,
+		locale,
+	);
 
-			const mappingStartTime = Date.now();
-			const expectedDocumentName = uploadDocumentDto.docName;
-			const vcMapping = isDhiwayVcUrl
-				? await this.prepareDhiwayVcMapping(ocrResult, uploadDocumentDto)
-				: await this.prepareVcMapping(ocrResult, uploadDocumentDto, expectedDocumentName, locale);
-			console.log('vcMapping ====>', vcMapping);
-			Logger.log(`⏱️ OCR Mapping took: ${Date.now() - mappingStartTime}ms`, 'UserService');
+	Logger.log(`Document validation passed, proceeding with document processing.`);
 
 			// Check for validation errors BEFORE proceeding with storage and VC creation
 			if ('validationErrors' in vcMapping && vcMapping.validationErrors && vcMapping.validationErrors.length > 0) {
@@ -3102,40 +3106,43 @@ export class UserService {
 				issuer,
 				requiresQRProcessing,
 				locale,
-			);
-			Logger.log(`⏱️ QR Content Processing took: ${Date.now() - ocrStartTime}ms`, 'UserService');
+		);
+		Logger.log(`⏱️ QR Content Processing took: ${Date.now() - ocrStartTime}ms`, 'UserService');
 
-			// Validate document type from QR processing result and VC fields
-			Logger.log(`Starting document validation: docName=${uploadDocumentQrDto.docName}, docType=${uploadDocumentQrDto.docType}, docSubType=${uploadDocumentQrDto.docSubType}`);
-			const isValidDocument = await this.validateDocumentAndFields(
-				documentConfig,
-				ocrResult,
-				uploadDocumentDto,
-				issueVC,
-				locale,
-			);
+		// Step 1: Keyword-based document validation (preValidation)
+		Logger.log(`Starting keyword-based document validation: docName=${uploadDocumentQrDto.docName}, docType=${uploadDocumentQrDto.docType}, docSubType=${uploadDocumentQrDto.docSubType}`);
+		const keywordValidationResult = await this.documentValidationService.validateDocument(
+			ocrResult.extractedText,
+			uploadDocumentQrDto.docType,
+			uploadDocumentQrDto.docSubType,
+		);
 
-			if (isValidDocument === false) {
-				const documentName = uploadDocumentQrDto.docName || 'Unknown';
-				Logger.warn(`Document validation failed - returning error. Expected document type: ${documentName}`);
-				const errorMessage = this.i18n.translateError('DOCUMENT_TYPE_MISMATCH', locale, { documentName });
-				return new ErrorResponse({
-					statusCode: HttpStatus.BAD_REQUEST,
-					errorMessage,
-				});
-			}
+		if (!keywordValidationResult.isValid) {
+			const documentName = uploadDocumentQrDto.docName || 'Unknown';
+			Logger.warn(`Keyword validation FAILED: ${keywordValidationResult.reason}`);
+			const errorMessage = this.i18n.translateError('DOCUMENT_TYPE_MISMATCH', locale, { 
+				documentName,
+				reason: keywordValidationResult.reason 
+			});
+			return new ErrorResponse({
+				statusCode: HttpStatus.BAD_REQUEST,
+				errorMessage,
+			});
+		}
 
-			Logger.log(`Document validation passed or skipped. isValidDocument=${isValidDocument}, proceeding with document processing.`);
+		Logger.log(`Keyword validation PASSED. Matched keywords: ${keywordValidationResult.matchedKeywords?.join(', ') || 'N/A'}`);
 
-			// Check if this is a Dhiway VC_URL case - skip OCR mapping and use VC data directly
-			const isDhiwayVcUrl = this.isDhiwayVcUrlDocument(ocrResult, uploadDocumentDto, documentConfig);
+	// Step 2: Validate document type from QR processing result and VC fields (includes OCR mapping)
+	Logger.log(`Starting field validation: docName=${uploadDocumentQrDto.docName}, docType=${uploadDocumentQrDto.docType}, docSubType=${uploadDocumentQrDto.docSubType}`);
+	const { vcMapping } = await this.validateDocumentAndFields(
+		documentConfig,
+		ocrResult,
+		uploadDocumentDto,
+		issueVC,
+		locale,
+	);
 
-			const mappingStartTime = Date.now();
-			const expectedDocumentName = uploadDocumentQrDto.docName;
-			const vcMapping = isDhiwayVcUrl
-				? await this.prepareDhiwayVcMapping(ocrResult, uploadDocumentDto)
-				: await this.prepareVcMapping(ocrResult, uploadDocumentDto, expectedDocumentName, locale);
-			Logger.log(`⏱️ OCR Mapping took: ${Date.now() - mappingStartTime}ms`, 'UserService');
+	Logger.log(`Document validation passed, proceeding with document processing.`);
 
 			// Check for validation errors BEFORE proceeding with storage and VC creation
 			if ('validationErrors' in vcMapping && vcMapping.validationErrors && vcMapping.validationErrors.length > 0) {
@@ -3404,7 +3411,7 @@ export class UserService {
 
 	/**
 	 * Validates document type from OCR text and required VC fields
-	 * @returns boolean | undefined - true if valid, false if invalid, undefined if validation not configured
+	 * Returns the vcMapping to avoid duplicate OCR mapping calls
 	 */
 	private async validateDocumentAndFields(
 		documentConfig: any,
@@ -3412,12 +3419,7 @@ export class UserService {
 		uploadDocumentDto: UploadDocumentDto,
 		issueVC: string,
 		locale: string = 'en',
-	): Promise<boolean | undefined> {
-		// Document type validation - now done by LLM during OCR mapping
-		let isValidDocument: boolean | undefined = undefined;
-		// Use docName from API payload instead of documentConfig.name
-		const expectedDocumentName = uploadDocumentDto.docName;
-
+	): Promise<{ vcMapping: any; isDhiwayVcUrl: boolean }> {
 		// Required field validation
 		const validationStartTime = Date.now();
 		Logger.log(`Validating document type and required fields`);
@@ -3429,7 +3431,7 @@ export class UserService {
 		const isDhiwayVcUrl = this.isDhiwayVcUrlDocument(ocrResult, uploadDocumentDto, documentConfig);
 		const vcMapping = isDhiwayVcUrl
 			? await this.prepareDhiwayVcMapping(ocrResult, uploadDocumentDto)
-			: await this.prepareVcMapping(ocrResult, uploadDocumentDto, expectedDocumentName, locale);
+			: await this.prepareVcMapping(ocrResult, uploadDocumentDto, locale);
 
 		// Check for validation errors BEFORE proceeding
 		if ('validationErrors' in vcMapping && vcMapping.validationErrors && vcMapping.validationErrors.length > 0) {
@@ -3439,25 +3441,8 @@ export class UserService {
 			throw new BadRequestException(translatedError);
 		}
 
-		// Check isValidDocument from LLM mapping result (only for non-Dhiway VC URL cases)
-		// THIS CHECK MUST HAPPEN BEFORE FIELD VALIDATION
-		// Use only LLM's response - no additional logic or validation
-		if (!isDhiwayVcUrl && vcMapping && 'isValidDocument' in vcMapping && vcMapping.isValidDocument !== undefined) {
-			isValidDocument = vcMapping.isValidDocument;
-			Logger.log(`Document type validation result from LLM: isValidDocument=${isValidDocument}`);
-
-			if (!isValidDocument) {
-				Logger.warn(`Document type validation FAILED: LLM determined document does not match expected type. Stopping validation and returning error.`);
-				return false;
-			}
-			Logger.log(`Document type validation PASSED: LLM confirmed document matches expected type. Proceeding with field validation.`);
-		} else if (isDhiwayVcUrl) {
-			// For Dhiway VC URL cases, skip document type validation as VC data is already validated
-			Logger.log(`Skipping document type validation for Dhiway VC URL case - VC data already validated`);
-		}
-
 		// Proceed to field validation
-		Logger.log(`Proceeding to field validation. isValidDocument=${isValidDocument}`);
+		Logger.log(`Proceeding to field validation`);
 
 		if (vcFields && Object.keys(vcFields).length > 0) {
 			await this.validateRequiredFieldsFromOcrMapping(
@@ -3474,8 +3459,8 @@ export class UserService {
 		}
 
 		Logger.log(`⏱️ Required Field Validation took: ${Date.now() - validationStartTime}ms`, 'UserService');
-
-		return isValidDocument;
+		
+		return { vcMapping, isDhiwayVcUrl };
 	}
 
 	/**
@@ -3715,7 +3700,6 @@ export class UserService {
 	private async prepareVcMapping(
 		ocrResult: any,
 		uploadDocumentDto: UploadDocumentDto,
-		expectedDocumentName: string,
 		locale: string = 'en',
 	) {
 		const vcFields = await this.vcFieldsService.getVcFields(
@@ -3736,11 +3720,6 @@ export class UserService {
 			};
 		}
 
-		// Ensure expectedDocumentName is provided (docName is required in DTO)
-		if (!expectedDocumentName || expectedDocumentName.trim() === '') {
-			throw new BadRequestException('DOCUMENT_NAME_REQUIRED_FOR_VALIDATION');
-		}
-
 		return await this.ocrMappingService.mapAfterOcr(
 			{
 				text: ocrResult.extractedText,
@@ -3748,7 +3727,6 @@ export class UserService {
 				docSubType: uploadDocumentDto.docSubType,
 			},
 			vcFields,
-			expectedDocumentName,
 			locale,
 		);
 	}
@@ -4187,7 +4165,6 @@ export class UserService {
 			Logger.log(
 				`Validating required fields - vcFields: ${Object.keys(vcFields || {}).length} fields, vcMapping present: ${!!vcMapping}`,
 			);
-			Logger.debug(`vcFields structure: ${JSON.stringify(vcFields, null, 2)}`);
 
 			if (!vcFields || !vcMapping) {
 				throw new ErrorResponse(

--- a/src/services/document-validation/document-validation.module.ts
+++ b/src/services/document-validation/document-validation.module.ts
@@ -1,0 +1,18 @@
+import { Module, Global } from '@nestjs/common';
+import { DocumentValidationService } from './document-validation.service';
+import { AdminModule } from '@modules/admin/admin.module';
+
+/**
+ * Document Validation Module
+ * Provides keyword-based document validation services
+ * 
+ * @Global - Makes DocumentValidationService available throughout the application
+ */
+@Global()
+@Module({
+  imports: [AdminModule],
+  providers: [DocumentValidationService],
+  exports: [DocumentValidationService],
+})
+export class DocumentValidationModule {}
+

--- a/src/services/document-validation/document-validation.service.ts
+++ b/src/services/document-validation/document-validation.service.ts
@@ -1,0 +1,219 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AdminService } from '@modules/admin/admin.service';
+
+/**
+ * Document Configuration Interface with pre-validation settings
+ */
+export interface DocumentValidationConfig {
+  name: string;
+  label: string;
+  docType: string;
+  documentSubType: string;
+  issueVC: string;
+  preValidationEnabled?: string; // "yes" or "no"
+  preValidationRequiredKeywords?: string[]; // Keywords that must be present for valid document
+  preValidationExclusionKeywords?: string[]; // Keywords that indicate invalid document
+  [key: string]: any; // Allow other fields
+}
+
+/**
+ * Document Validation Result
+ */
+export interface DocumentValidationResult {
+  isValid: boolean;
+  reason?: string; // Reason for validation failure
+  matchedKeywords?: string[]; // Keywords that were matched
+}
+
+/**
+ * Service for keyword-based document validation
+ * Validates documents based on preValidation configuration in vcConfiguration
+ */
+@Injectable()
+export class DocumentValidationService {
+  private readonly logger = new Logger(DocumentValidationService.name);
+
+  constructor(private readonly adminService: AdminService) {}
+
+  /**
+   * Validate document based on keyword matching
+   * @param extractedText - Text extracted from document via OCR
+   * @param docType - Document type
+   * @param docSubType - Document subtype
+   * @returns Validation result with isValid flag and reason
+   */
+  async validateDocument(
+    extractedText: string,
+    docType: string,
+    docSubType: string,
+  ): Promise<DocumentValidationResult> {
+    try {
+      // Get document configuration
+      const config = await this.getDocumentConfig(docType, docSubType);
+
+      if (!config) {
+        this.logger.warn(
+          `No configuration found for docType: ${docType}, docSubType: ${docSubType}. Skipping validation.`,
+        );
+        return { isValid: true }; // If no config, allow document
+      }
+
+      // Check if pre-validation is enabled
+      const preValidationEnabled = config.preValidationEnabled?.toLowerCase() === 'yes';
+      
+      if (!preValidationEnabled) {
+        this.logger.log(
+          `Pre-validation disabled for ${docType}/${docSubType}. Skipping keyword validation.`,
+        );
+        return { isValid: true };
+      }
+
+      this.logger.log(
+        `Pre-validation enabled for ${docType}/${docSubType}. Performing keyword validation.`,
+      );
+
+      // Normalize extracted text for case-insensitive matching
+      // Also normalize whitespace: convert newlines, tabs, multiple spaces to single space
+      const normalizedText = extractedText
+        .toLowerCase()
+        .replaceAll('\n', ' ')  // Convert newlines to spaces
+        .replaceAll('\r', ' ')  // Convert carriage returns to spaces
+        .replaceAll('\t', ' ')  // Convert tabs to spaces
+        // eslint-disable-next-line unicorn/prefer-string-replace-all
+        .replace(/\s+/g, ' ')   // Convert multiple spaces to single space
+        .trim();
+      
+      // Log a sample of the normalized text for debugging
+      const textSample = normalizedText.substring(0, 200);
+      this.logger.debug(
+        `Normalized text sample (first 200 chars): "${textSample}..."`,
+      );
+
+      // Check exclusion keywords first (if present, document is invalid)
+      if (config.preValidationExclusionKeywords && config.preValidationExclusionKeywords.length > 0) {
+        this.logger.debug(
+          `Checking ${config.preValidationExclusionKeywords.length} exclusion keyword(s): [${config.preValidationExclusionKeywords.join(', ')}]`,
+        );
+        
+        const matchedExclusionKeywords = config.preValidationExclusionKeywords.filter((keyword) => {
+          const normalizedKeyword = keyword.toLowerCase();
+          const isFound = normalizedText.includes(normalizedKeyword);
+          this.logger.debug(`  - Exclusion keyword "${keyword}" (normalized: "${normalizedKeyword}"): ${isFound ? 'FOUND ❌' : 'not found ✓'}`);
+          return isFound;
+        });
+
+        if (matchedExclusionKeywords.length > 0) {
+          this.logger.warn(
+            `Document validation FAILED: Found exclusion keyword(s): ${matchedExclusionKeywords.join(', ')}`,
+          );
+          return {
+            isValid: false,
+            reason: `Document contains exclusion keyword(s): ${matchedExclusionKeywords.join(', ')}`,
+            matchedKeywords: matchedExclusionKeywords,
+          };
+        }
+        
+        this.logger.debug(`No exclusion keywords found ✓`);
+      }
+
+      // Check required keywords (at least one must be present)
+      if (config.preValidationRequiredKeywords && config.preValidationRequiredKeywords.length > 0) {
+        this.logger.debug(
+          `Checking ${config.preValidationRequiredKeywords.length} required keyword(s): [${config.preValidationRequiredKeywords.join(', ')}]`,
+        );
+        
+        const matchedRequiredKeywords = config.preValidationRequiredKeywords.filter((keyword) => {
+          const normalizedKeyword = keyword.toLowerCase();
+          const isFound = normalizedText.includes(normalizedKeyword);
+          this.logger.debug(`  - Required keyword "${keyword}" (normalized: "${normalizedKeyword}"): ${isFound ? 'FOUND ✓' : 'NOT FOUND ❌'}`);
+          return isFound;
+        });
+
+        if (matchedRequiredKeywords.length === 0) {
+          this.logger.warn(
+            `Document validation FAILED: None of the required keywords found. Expected: ${config.preValidationRequiredKeywords.join(', ')}. ` +
+            `Text sample: "${textSample}..."`,
+          );
+          return {
+            isValid: false,
+            reason: `Document does not contain any of the required keywords: ${config.preValidationRequiredKeywords.join(', ')}`,
+            matchedKeywords: [],
+          };
+        }
+
+        this.logger.log(
+          `Document validation PASSED: Found required keyword(s): ${matchedRequiredKeywords.join(', ')} (matched ${matchedRequiredKeywords.length}/${config.preValidationRequiredKeywords.length})`,
+        );
+        return {
+          isValid: true,
+          matchedKeywords: matchedRequiredKeywords,
+        };
+      }
+
+      // If no keywords configured, allow document
+      this.logger.log(
+        `No validation keywords configured for ${docType}/${docSubType}. Allowing document.`,
+      );
+      return { isValid: true };
+    } catch (error: any) {
+      this.logger.error(
+        `Document validation error: ${error?.message || error}`,
+        error.stack,
+      );
+      // On error, allow document to proceed (fail-open approach)
+      return { isValid: true };
+    }
+  }
+
+  /**
+   * Get document configuration from vcConfiguration
+   * @param docType - Document type
+   * @param docSubType - Document subtype
+   * @returns Document configuration or null if not found
+   */
+  private async getDocumentConfig(
+    docType: string,
+    docSubType: string,
+  ): Promise<DocumentValidationConfig | null> {
+    try {
+      const vcConfig = await this.adminService.getConfigByKey('vcConfiguration');
+
+      if (!vcConfig?.value) {
+        this.logger.warn('vcConfiguration not found in settings');
+        return null;
+      }
+
+      // Handle both array and JSON string formats
+      const configValue = Array.isArray(vcConfig.value)
+        ? vcConfig.value
+        : JSON.parse(vcConfig.value);
+
+      if (!Array.isArray(configValue)) {
+        this.logger.warn('vcConfiguration is not an array');
+        return null;
+      }
+
+      // Find matching configuration
+      const matchingConfig = configValue.find(
+        (config: any) =>
+          config.docType === docType && config.documentSubType === docSubType,
+      );
+
+      if (!matchingConfig) {
+        this.logger.warn(
+          `No matching configuration found for docType: ${docType}, documentSubType: ${docSubType}`,
+        );
+        return null;
+      }
+
+      return matchingConfig as DocumentValidationConfig;
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to get document configuration: ${error?.message || error}`,
+        error.stack,
+      );
+      return null;
+    }
+  }
+}
+

--- a/src/services/document-validation/index.ts
+++ b/src/services/document-validation/index.ts
@@ -1,0 +1,3 @@
+export * from './document-validation.service';
+export * from './document-validation.module';
+

--- a/src/services/ocr-mapping/adapters/bedrock.adapter.ts
+++ b/src/services/ocr-mapping/adapters/bedrock.adapter.ts
@@ -49,7 +49,6 @@ export class BedrockAdapter implements IAiMappingAdapter {
   async mapTextToSchema(
     extractedText: string, 
     schema: Record<string, any>, 
-    expectedDocumentName: string, 
     docType?: string,
     customPromptTemplate?: string | null
   ): Promise<Record<string, any> | null> {
@@ -59,11 +58,11 @@ export class BedrockAdapter implements IAiMappingAdapter {
     }
 
     try {
-      const prompt = buildOcrMappingPrompt(extractedText, schema, expectedDocumentName, customPromptTemplate);
+      const prompt = buildOcrMappingPrompt(extractedText, schema, customPromptTemplate);
       if (customPromptTemplate) {
         this.logger.debug(`Using custom prompt from vcConfiguration for Bedrock mapping`);
       }
-      this.logger.debug(`Sending request to Bedrock (${Object.keys(schema.properties || {}).length} fields, expectedDocumentName: ${expectedDocumentName})`);
+      this.logger.debug(`Sending request to Bedrock (${Object.keys(schema.properties || {}).length} fields)`);
       const response = await this.invokeModel(prompt);
       const parsedResult = JsonParserUtil.parseAiResponse(response, 'bedrock');
       
@@ -72,7 +71,7 @@ export class BedrockAdapter implements IAiMappingAdapter {
         return null;
       }
       
-      this.logger.debug(`Bedrock extracted ${Object.keys(parsedResult).length} fields, isValidDocument: ${parsedResult.isValidDocument}`);
+      this.logger.debug(`Bedrock extracted ${Object.keys(parsedResult).length} fields`);
       return parsedResult;
     } catch (error: any) {
       this.logger.error(`Bedrock mapping failed: ${error?.message || error}`);

--- a/src/services/ocr-mapping/adapters/gemini.adapter.ts
+++ b/src/services/ocr-mapping/adapters/gemini.adapter.ts
@@ -37,7 +37,6 @@ export class GeminiAdapter implements IAiMappingAdapter {
   async mapTextToSchema(
     extractedText: string, 
     schema: Record<string, any>, 
-    expectedDocumentName: string, 
     docType?: string,
     customPromptTemplate?: string | null
   ): Promise<Record<string, any> | null> {
@@ -47,11 +46,11 @@ export class GeminiAdapter implements IAiMappingAdapter {
     }
 
     try {
-      const prompt = buildOcrMappingPrompt(extractedText, schema, expectedDocumentName, customPromptTemplate);
+      const prompt = buildOcrMappingPrompt(extractedText, schema, customPromptTemplate);
       if (customPromptTemplate) {
         this.logger.debug(`Using custom prompt from vcConfiguration for Gemini mapping`);
       }
-      this.logger.debug(`Sending request to Gemini (${Object.keys(schema.properties || {}).length} fields, expectedDocumentName: ${expectedDocumentName})`);
+      this.logger.debug(`Sending request to Gemini (${Object.keys(schema.properties || {}).length} fields)`);
       
       const response = await this.invokeModel(prompt);
       const parsedResult = JsonParserUtil.parseAiResponse(response, 'gemini');
@@ -61,7 +60,7 @@ export class GeminiAdapter implements IAiMappingAdapter {
         return null;
       }
       
-      this.logger.debug(`Gemini extracted ${Object.keys(parsedResult).length} fields, isValidDocument: ${parsedResult.isValidDocument}`);
+      this.logger.debug(`Gemini extracted ${Object.keys(parsedResult).length} fields`);
       return parsedResult;
     } catch (error: any) {
       this.logger.error(`Gemini mapping failed: ${error?.message || error}`);

--- a/src/services/ocr-mapping/interfaces/ocr-mapping.interface.ts
+++ b/src/services/ocr-mapping/interfaces/ocr-mapping.interface.ts
@@ -17,7 +17,6 @@ export interface OcrMappingResult {
   processing_method: 'ai' | 'keyword' | 'hybrid';
   warnings?: string[];
   validationErrors?: Array<{ field: string; error: string; constraint: string }>;
-  isValidDocument?: boolean; // Document type validation result from LLM semantic analysis
 }
 
 /**
@@ -28,15 +27,13 @@ export interface IAiMappingAdapter {
    * Map extracted text to structured data using AI
    * @param extractedText - Raw text from OCR
    * @param schema - Target JSON schema
-   * @param expectedDocumentName - Expected document type name for validation
    * @param docType - Optional document type for context-specific processing
    * @param customPromptTemplate - Optional custom prompt template from vcConfiguration
-   * @returns Mapped data object with isValidDocument field, or null if failed
+   * @returns Mapped data object, or null if failed
    */
   mapTextToSchema(
     extractedText: string, 
     schema: Record<string, any>, 
-    expectedDocumentName: string, 
     docType?: string,
     customPromptTemplate?: string | null
   ): Promise<Record<string, any> | null>;

--- a/src/services/ocr-mapping/ocr-mapping.service.ts
+++ b/src/services/ocr-mapping/ocr-mapping.service.ts
@@ -26,18 +26,11 @@ export class OcrMappingService {
    * Map OCR text to structured data after OCR processing
    * @param input - OCR mapping input containing text and document info
    * @param vcFields - VcFields configuration for the document type
-   * @param expectedDocumentName - Expected document type name for validation
    * @param locale - Language locale for validation messages (en, hi)
    */
-  async mapAfterOcr(input: OcrMappingInput, vcFields: VcFields, expectedDocumentName: string, locale: string = 'en'): Promise<OcrMappingResult> {
+  async mapAfterOcr(input: OcrMappingInput, vcFields: VcFields, locale: string = 'en'): Promise<OcrMappingResult> {
     try {
-      // Validate expectedDocumentName is provided
-      if (!expectedDocumentName || expectedDocumentName.trim() === '') {
-        this.logger.error('expectedDocumentName is required for OCR mapping');
-        throw new Error('EXPECTED_DOCUMENT_NAME_REQUIRED');
-      }
-      
-      this.logger.log(`OCR mapping started: ${input.docType}/${input.docSubType}, expectedDocumentName: ${expectedDocumentName}, locale: ${locale}`);
+      this.logger.log(`OCR mapping started: ${input.docType}/${input.docSubType}, locale: ${locale}`);
       if (!vcFields || Object.keys(vcFields).length === 0) {
         this.logger.warn(`No vcFields provided for mapping`);
         return {
@@ -67,7 +60,7 @@ export class OcrMappingService {
 
       // Use AI mapping
       const startTime = Date.now();
-      const mappedData: Record<string, any> | null = await this.tryAiMapping(adapterType, input.text, schema, expectedDocumentName, customPromptTemplate);
+      const mappedData: Record<string, any> | null = await this.tryAiMapping(adapterType, input.text, schema, customPromptTemplate);
       this.logger.log(`⏱️ AI Mapping Logic took: ${Date.now() - startTime}ms`);
       
       // Log raw mapped data from AI
@@ -82,21 +75,7 @@ export class OcrMappingService {
       
       const processingMethod: 'ai' | 'keyword' | 'hybrid' = mappedData && Object.keys(mappedData).length > 0 ? 'ai' : 'keyword';
 
-      // Extract isValidDocument from mappedData if present
-      let isValidDocument: boolean | undefined = undefined;
-      if (mappedData && 'isValidDocument' in mappedData) {
-        isValidDocument = mappedData.isValidDocument;
-        this.logger.log(`Document type validation result from LLM: isValidDocument=${isValidDocument}, expectedDocumentName=${expectedDocumentName}`);
-        
-        // Remove isValidDocument from mappedData to avoid including it in the data fields
-        const { isValidDocument: _, ...dataWithoutValidation } = mappedData;
-        return this.computeResultFromMappedData(dataWithoutValidation, vcFields, processingMethod, isValidDocument, locale);
-      } else if (mappedData) {
-        // If isValidDocument is missing from response, log warning (but still proceed)
-        this.logger.warn(`Expected document type "${expectedDocumentName}" was provided but LLM response does not contain isValidDocument field. Response keys: ${Object.keys(mappedData).join(', ')}`);
-      }
-
-      return this.computeResultFromMappedData(mappedData, vcFields, processingMethod, isValidDocument, locale);
+      return this.computeResultFromMappedData(mappedData, vcFields, processingMethod, locale);
 
     } catch (error: any) {
       this.logger.error(`OCR mapping failed: ${error?.message || error}`);
@@ -117,7 +96,6 @@ export class OcrMappingService {
     adapterType: string, 
     text: string, 
     schema: Record<string, any>, 
-    expectedDocumentName: string,
     customPromptTemplate?: string | null
   ): Promise<Record<string, any> | null> {
     if (!((adapterType === 'bedrock' || adapterType === 'google-gemini') && this.aiAdapter.isConfigured())) {
@@ -125,7 +103,7 @@ export class OcrMappingService {
     }
 
     try {
-      const mappedData = await this.aiAdapter.mapTextToSchema(text, schema, expectedDocumentName, undefined, customPromptTemplate);
+      const mappedData = await this.aiAdapter.mapTextToSchema(text, schema, undefined, customPromptTemplate);
 
       // Check if the response is the full AI response object instead of parsed JSON
       if (mappedData && typeof mappedData === 'object' && ('generation' in mappedData || 'content' in mappedData)) {
@@ -135,7 +113,7 @@ export class OcrMappingService {
 
       if (mappedData && Object.keys(mappedData).length > 0) {
         const fieldCount = Object.keys(schema.properties || {}).length;
-        this.logger.log(`AI mapping successful: ${Object.keys(mappedData).length}/${fieldCount} fields extracted, isValidDocument: ${mappedData.isValidDocument}`);
+        this.logger.log(`AI mapping successful: ${Object.keys(mappedData).length}/${fieldCount} fields extracted`);
         return mappedData;
       }
 
@@ -154,7 +132,6 @@ export class OcrMappingService {
     mappedData: Record<string, any> | null,
     vcFields: VcFields,
     processingMethod: 'ai' | 'keyword' | 'hybrid',
-    isValidDocument?: boolean,
     locale: string = 'en',
   ): OcrMappingResult {
     mappedData = mappedData || {};
@@ -213,17 +190,13 @@ export class OcrMappingService {
       });
     }
 
-    // Ensure isValidDocument is not included in mapped_data (it's a metadata field, not a data field)
-    const { isValidDocument: _, ...finalMappedData } = validationResult.data;
-
     return {
-      mapped_data: finalMappedData,
+      mapped_data: validationResult.data,
       missing_fields: missingFields,
       confidence,
       processing_method: processingMethod,
       warnings: validationResult.warnings,
       validationErrors: validationResult.validationErrors.length > 0 ? validationResult.validationErrors : undefined,
-      isValidDocument,
     };
   }
 

--- a/src/services/storage-providers/adapters/s3.storage.adapter.ts
+++ b/src/services/storage-providers/adapters/s3.storage.adapter.ts
@@ -85,7 +85,7 @@ export class S3StorageAdapter implements IFileStorageService {
           // If ACLs are disabled or IAM doesn't have ACL permissions, fallback to private upload
           // Public access can be handled via bucket policies or CloudFront
           this.logger.warn(
-            `⚠️ Cannot upload as PUBLIC (ACL/permission issue) - uploading as PRIVATE instead. ` +
+            `Cannot upload as PUBLIC (ACL/permission issue) - uploading as PRIVATE instead. ` +
             `Key: ${key}. ` +
             `Error: ${errorMessage.substring(0, 200)}. ` +
             `To enable public URLs, configure bucket policies to allow public read access (s3:GetObject). ` +
@@ -98,7 +98,7 @@ export class S3StorageAdapter implements IFileStorageService {
         } else if (isAclError && !isPublic) {
           // Even private upload failed with ACL error - this shouldn't happen, but handle it
           this.logger.warn(
-            `⚠️ ACL error on private upload, retrying: ${key}. Error: ${errorMessage.substring(0, 200)}`,
+            `ACL error on private upload, retrying: ${key}. Error: ${errorMessage.substring(0, 200)}`,
           );
           await storage.write(key, content, {
             visibility: Visibility.PRIVATE,
@@ -112,7 +112,7 @@ export class S3StorageAdapter implements IFileStorageService {
       // Log final upload status
       if (isPublic && !uploadedAsPublic) {
         this.logger.warn(
-          `⚠️ File uploaded as PRIVATE but public URL will be generated. ` +
+          `File uploaded as PRIVATE but public URL will be generated. ` +
           `Ensure bucket policies allow public read access for URL to work. Key: ${key}`,
         );
       }


### PR DESCRIPTION
Removed LLM-dependent document validation (isValidDocument) from prompts, adapters, and services to save costs and reduce latency. 
Replaced it with a deterministic Keyword-based Validation Service that checks for required and excluded terms defined in the vcConfiguration. This shift ensures validation happens before data mapping, making the system faster and more predictable.